### PR TITLE
add R-universe source for RSocrata

### DIFF
--- a/.github/workflows/snapshot-nhsn-data.yml
+++ b/.github/workflows/snapshot-nhsn-data.yml
@@ -24,7 +24,9 @@ jobs:
           r-version: 4.4.1
           install-r: true
           use-public-rspm: true
-          extra-repositories: 'https://hubverse-org.r-universe.dev'
+          extra-repositories: 
+            - 'https://hubverse-org.r-universe.dev'
+            - 'https://chicago.r-universe.dev/'
 
       - name: install ubuntu requirements
         run: |

--- a/.github/workflows/snapshot-nhsn-data.yml
+++ b/.github/workflows/snapshot-nhsn-data.yml
@@ -24,9 +24,7 @@ jobs:
           r-version: 4.4.1
           install-r: true
           use-public-rspm: true
-          extra-repositories: 
-            - 'https://hubverse-org.r-universe.dev'
-            - 'https://chicago.r-universe.dev/'
+          extra-repositories: 'https://hubverse-org.r-universe.dev'
 
       - name: install ubuntu requirements
         run: |
@@ -34,7 +32,7 @@ jobs:
 
       - name: install R packages
         run: |
-          Rscript -e "install.packages('RSocrata')"
+          Rscript -e "install.packages('RSocrata', repos = c('https://chicago.r-universe.dev/', getOption('repos')))"
       
       - name: Get file name
         run: echo "FILE_NAME=nhsn-$(date +'%Y-%m-%d').csv" >> $GITHUB_ENV

--- a/.github/workflows/snapshot-nhsn-data.yml
+++ b/.github/workflows/snapshot-nhsn-data.yml
@@ -1,6 +1,8 @@
 name: Snapshot NHSN data and upload to S3
 
 on:
+  pull_request:
+    branches: 'main'
   schedule:
     - cron: "45 17 * * 3" # every Wednesday at 5:45PM UTC == 12:45PM EST
   workflow_dispatch:
@@ -54,5 +56,6 @@ jobs:
           aws-region: us-east-1
 
       - name: Copy files to cloud storage
+        if: github.event_name != 'pull_request'
         run: |
           aws s3 cp "./$FILE_NAME" "s3://infectious-disease-data/data-raw/influenza-nhsn/$FILE_NAME"


### PR DESCRIPTION
This will address the failure from last week.

The reason this failed was because CRAN removed the RSocrata package for test failures on M1 Mac. The [maintainers were notified that they had two weeks to fix the issue](https://github.com/chicago/rsocrata/issues/233) before the package would be removed from CRAN. However, this was happening at a time that [RSocrata was undergoing a maintenance shift](https://github.com/Chicago/RSocrata/issues/232), so the deadline lapsed and RSocrata was removed. 

Luckily, the R-universe has a backup copy of the package that was built two weeks ago: https://chicago.r-universe.dev/RSocrata