### PR TITLE
Remove snapshot action runs on PRs to main

### DIFF
--- a/.github/workflows/snapshot-nhsn-data.yml
+++ b/.github/workflows/snapshot-nhsn-data.yml
@@ -1,8 +1,6 @@
 name: Snapshot NHSN data and upload to S3
 
 on:
-  pull_request:
-    branches: 'main'
   schedule:
     - cron: "45 17 * * 3" # every Wednesday at 5:45PM UTC == 12:45PM EST
   workflow_dispatch:

--- a/.github/workflows/snapshot-nssp-data.yml
+++ b/.github/workflows/snapshot-nssp-data.yml
@@ -1,8 +1,6 @@
 name: Snapshot NSSP data and upload to S3
 
 on:
-  pull_request:
-    branches: 'main'
   schedule:
     - cron: "45 17 * * 3,5" # every Wednesday and Friday at 5:45PM UTC == 12:45PM EST
   workflow_dispatch:


### PR DESCRIPTION
Snapshot actions always fail on PRs because they don't have the authority to access the credentials needed to run. This PR restricts their runs to only be as scheduled on main to capture the data updates we need to run our weekly models.