### PR TITLE
Add HSA population data to PopulationData ancillary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "pymmwr",
     "rich",
     "s3fs",
-    "toml"
+    "toml",
+    "xlrd",
 ]
 
 [project.optional-dependencies]

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -20,6 +20,8 @@ botocore==1.35.36
     # via aiobotocore
 cfgv==3.4.0
     # via pre-commit
+colorama==0.4.6
+    # via pytest
 coverage==7.5.1
     # via iddata (pyproject.toml)
 distlib==0.3.8
@@ -82,7 +84,7 @@ pyyaml==6.0.1
     # via pre-commit
 rich==13.7.1
     # via iddata (pyproject.toml)
-ruff==0.4.3
+ruff==0.15.22
     # via iddata (pyproject.toml)
 s3fs==2024.10.0
     # via iddata (pyproject.toml)
@@ -102,5 +104,7 @@ virtualenv==20.26.1
     # via pre-commit
 wrapt==1.16.0
     # via aiobotocore
+xlrd==2.0.2
+    # via iddata (pyproject.toml)
 yarl==1.17.1
     # via aiohttp

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -68,5 +68,7 @@ urllib3==2.2.3
     # via botocore
 wrapt==1.16.0
     # via aiobotocore
+xlrd==2.0.2
+    # via iddata (pyproject.toml)
 yarl==1.17.1
     # via aiohttp

--- a/src/iddata/__init__.py
+++ b/src/iddata/__init__.py
@@ -1,4 +1,4 @@
 from iddata.enums import AggLevel, Disease, SourceType
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __all__ = ["AggLevel", "Disease", "SourceType"]

--- a/src/iddata/ancillary/population.py
+++ b/src/iddata/ancillary/population.py
@@ -7,6 +7,16 @@ import pandas as pd
 from iddata.ancillary.base import AncillaryData
 from iddata.constants import S3_DATA_RAW_URL
 
+_SEER_HSA_CROSSWALK_URL = "https://seer.cancer.gov/seerstat/variables/countyattribs/Health.Service.Areas.xls"
+_CENSUS_COUNTY_URL = "https://www2.census.gov/programs-surveys/popest/datasets/2020-2024/counties/totals/co-est2024-alldata.csv"
+_CENSUS_COUNTY_2010_2019_URL = "https://www2.census.gov/programs-surveys/popest/datasets/2010-2019/counties/totals/co-est2019-alldata.csv"
+
+# FIPS codes retired after the crosswalk was last published; maps old code -> list of current replacements
+_STALE_FIPS = {
+    "02270": ["02158"],          # Wade Hampton Census Area renamed Kusilvak (2015)
+    "02261": ["02063", "02066"], # Valdez-Cordova split into Chugach + Copper River (2019)
+}
+
 
 def _load_us_census() -> pd.DataFrame:
     """Load US Census population data (location × season)."""
@@ -41,6 +51,8 @@ def _load_us_census() -> pd.DataFrame:
         .rename(columns={"hhs_region": "location"})
     )
     dat = pd.concat([us_pops, hhs_pops], axis=0)
+    dat["agg_level"] = np.where(dat["location"] == "US", "national",
+                       np.where(dat["location"].str.startswith("Region"), "hhs region", "state"))
 
     all_locations = dat["location"].unique()
     all_seasons = [str(y) + "/" + str(y + 1)[-2:] for y in range(1997, 2026)]
@@ -58,6 +70,88 @@ def _load_us_census() -> pd.DataFrame:
     return dat
 
 
+def _load_county_pop_long(url: str) -> pd.DataFrame:
+    """Fetch a Census county population file and return (fips, year, pop) in long format."""
+    df = pd.read_csv(url, encoding="latin-1", dtype={"STATE": str, "COUNTY": str})
+    df = df[df["COUNTY"] != "000"].copy()
+    df["fips"] = df["STATE"].str.zfill(2) + df["COUNTY"].str.zfill(3)
+    pop_cols = [c for c in df.columns if c.startswith("POPESTIMATE")]
+    long = df[["fips"] + pop_cols].melt(id_vars="fips", var_name="year_col", value_name="pop")
+    long["year"] = long["year_col"].str.replace("POPESTIMATE", "").astype(int)
+    return long[["fips", "year", "pop"]]
+
+
+def _load_hsa_populations() -> pd.DataFrame:
+    """Load HSA-level population by aggregating Census county data via the NCI SEER crosswalk."""
+    # --- Crosswalk ---
+    raw = pd.read_excel(_SEER_HSA_CROSSWALK_URL, sheet_name="HSA (NCI Modified)", header=None, engine="xlrd")
+    crosswalk = (
+        raw.iloc[1:]
+        .rename(columns={0: "location", 1: "hsa_name", 2: "state_county", 3: "fips"})
+        .assign(
+            location=lambda x: x["location"].astype(str).str.strip(),
+            fips=lambda x: x["fips"].astype(str).str.zfill(5),
+        )[["location", "fips"]]
+        .drop_duplicates()
+    )
+    # Drop Census placeholder codes (county portion >= 900, e.g. 02900, 02999, 09999, 15900-15999)
+    crosswalk = crosswalk[crosswalk["fips"].str[2:].astype(int) < 900]
+    # Replace stale FIPS codes with their current equivalents
+    replacement_rows = []
+    stale_mask = crosswalk["fips"].isin(_STALE_FIPS)
+    for _, row in crosswalk[stale_mask].iterrows():
+        for new_fips in _STALE_FIPS[row["fips"]]:
+            replacement_rows.append({"location": row["location"], "fips": new_fips})
+    crosswalk = pd.concat(
+        [crosswalk[~stale_mask], pd.DataFrame(replacement_rows)], ignore_index=True
+    )
+
+    # --- Census county populations ---
+    # Use the 2020-2024 file for all states except CT: CT reorganized counties in 2022 and the
+    # new planning-region FIPS (09110-09190) don't match the old county codes in the crosswalk.
+    pop_recent = _load_county_pop_long(_CENSUS_COUNTY_URL)
+    pop_non_ct = pop_recent[~pop_recent["fips"].str.startswith("09")]
+    # Use the 2010-2019 file for CT only: old county FIPS (09001-09015) match the crosswalk exactly.
+    pop_ct = _load_county_pop_long(_CENSUS_COUNTY_2010_2019_URL)
+    pop_ct = pop_ct[pop_ct["fips"].str.startswith("09")]
+
+    county_pop = pd.concat([pop_non_ct, pop_ct], axis=0, ignore_index=True)
+
+    # --- Aggregate to HSA via crosswalk ---
+    merged = crosswalk.merge(county_pop, on="fips", how="left")
+    hsa_long = merged.groupby(["location", "year"])["pop"].sum(min_count=1).reset_index()
+    hsa_long = hsa_long.dropna(subset=["year"])
+    hsa_long["year"] = hsa_long["year"].astype(int)
+
+    # --- HSA 996 (Alaska) and 997 (Hawaii): crosswalk uses fake FIPS for these whole-state HSAs;
+    #     use state totals from the 2020-2024 Census file instead. ---
+    ak_hi = pop_recent[pop_recent["fips"].str[:2].isin(["02", "15"])].copy()
+    ak_hi["location"] = ak_hi["fips"].str[:2].map({"02": "996", "15": "997"})
+    ak_hi_long = ak_hi.groupby(["location", "year"])["pop"].sum(min_count=1).reset_index()
+    hsa_long = pd.concat([hsa_long, ak_hi_long], axis=0, ignore_index=True)
+
+    # --- Convert year to season string (e.g. 2023 -> "2023/24") ---
+    hsa_long["season"] = hsa_long["year"].astype(str) + "/" + hsa_long["year"].apply(lambda y: str(y + 1)[-2:])
+    hsa_long = hsa_long[["location", "season", "pop"]]
+
+    # --- Extend to all seasons via forward/backward fill (matching the approach in _load_us_census) ---
+    all_seasons = [str(y) + "/" + str(y + 1)[-2:] for y in range(1997, 2026)]
+    full_result = pd.DataFrame.from_records(
+        product(hsa_long["location"].unique(), all_seasons), columns=["location", "season"]
+    )
+    result = (
+        full_result.merge(hsa_long, how="left", on=["location", "season"])
+        .set_index("location")
+        .groupby("location")
+        .bfill()
+        .groupby("location")
+        .ffill()
+        .reset_index()
+    )
+    result["agg_level"] = "hsa"
+    return result
+
+
 class PopulationData(AncillaryData):
     """
     US Census population by location and season.
@@ -72,7 +166,11 @@ class PopulationData(AncillaryData):
     def load(self) -> pd.DataFrame:
         """Load population data from S3, returning per-location-season estimates."""
         census = _load_us_census()
-        census = census[["location", "season", "pop"]]
-        census = census[~census["pop"].isna()]
-        census["log_pop"] = np.log(census["pop"])
-        return census
+        hsa = _load_hsa_populations()
+        dat = pd.concat(
+            [census[["location", "season", "pop", "agg_level"]], hsa[["location", "season", "pop", "agg_level"]]],
+            axis=0,
+        )
+        dat = dat[~dat["pop"].isna()]
+        dat["log_pop"] = np.log(dat["pop"])
+        return dat

--- a/src/iddata/ancillary/population.py
+++ b/src/iddata/ancillary/population.py
@@ -73,7 +73,9 @@ def _load_us_census() -> pd.DataFrame:
 def _load_county_pop_long(url: str) -> pd.DataFrame:
     """Fetch a Census county population file and return (fips, year, pop) in long format."""
     df = pd.read_csv(url, encoding="latin-1", dtype={"STATE": str, "COUNTY": str})
+    # filter state-level rows + avoid SettingWithCopyWarning with an independent df
     df = df[df["COUNTY"] != "000"].copy()
+    # concatenate zero-padded state and county codes to standard 5 digit fips
     df["fips"] = df["STATE"].str.zfill(2) + df["COUNTY"].str.zfill(3)
     pop_cols = [c for c in df.columns if c.startswith("POPESTIMATE")]
     long = df[["fips"] + pop_cols].melt(id_vars="fips", var_name="year_col", value_name="pop")
@@ -83,12 +85,12 @@ def _load_county_pop_long(url: str) -> pd.DataFrame:
 
 def _load_hsa_populations() -> pd.DataFrame:
     """Load HSA-level population by aggregating Census county data via the NCI SEER crosswalk."""
-    # --- Crosswalk ---
+    # --- Crosswalk --- (header row is not in a clean, parsable format so we drop it)
     raw = pd.read_excel(_SEER_HSA_CROSSWALK_URL, sheet_name="HSA (NCI Modified)", header=None, engine="xlrd")
     crosswalk = (
-        raw.iloc[1:]
+        raw.iloc[1:] # remove header row from data
         .rename(columns={0: "location", 1: "hsa_name", 2: "state_county", 3: "fips"})
-        .assign(
+        .assign(# strip whitespace "location" and zero pad "fips"
             location=lambda x: x["location"].astype(str).str.strip(),
             fips=lambda x: x["fips"].astype(str).str.zfill(5),
         )[["location", "fips"]]
@@ -119,6 +121,7 @@ def _load_hsa_populations() -> pd.DataFrame:
 
     # --- Aggregate to HSA via crosswalk ---
     merged = crosswalk.merge(county_pop, on="fips", how="left")
+    # sum county populations to hsa-level; keep NA if all counties NA
     hsa_long = merged.groupby(["location", "year"])["pop"].sum(min_count=1).reset_index()
     hsa_long = hsa_long.dropna(subset=["year"])
     hsa_long["year"] = hsa_long["year"].astype(int)

--- a/src/iddata/loader.py
+++ b/src/iddata/loader.py
@@ -59,11 +59,8 @@ class DiseaseDataLoader:
             for anc in ancillary:
                 anc_df = anc.load()
                 join_keys = ["location", "season"] if "season" in anc_df.columns else ["location"]
+                if "agg_level" in anc_df.columns and "agg_level" in df.columns:
+                    join_keys.append("agg_level")
                 df = df.merge(anc_df, how="left", on=join_keys)
 
-            # Census doesn't provide HSA pop; null it out to avoid spurious joins
-            if "pop" in df.columns:
-                df["pop"] = np.where(df["agg_level"] == "hsa", np.nan, df["pop"])
-            if "log_pop" in df.columns:
-                df["log_pop"] = np.where(df["agg_level"] == "hsa", np.nan, df["log_pop"])
         return df

--- a/src/iddata/sources/flusurvnet.py
+++ b/src/iddata/sources/flusurvnet.py
@@ -114,7 +114,7 @@ class FluSurvNetDataSource(DataSource):
         burden_adj = dat[dat["location"] == "Entire Network"].groupby("season")["inc"].sum().reset_index()
         burden_adj.columns = ["season", "cum_rate"]
 
-        us_census = _load_us_census().query("location == 'US'").drop("location", axis=1)
+        us_census = _load_us_census().query("location == 'US'")[["season", "pop"]]
         burden_adj = pd.merge(burden_adj, us_census, on="season")
 
         burden_estimates = pd.read_csv(urljoin(S3_DATA_RAW_URL, "burden-estimates/burden-estimates.csv"),

--- a/tests/iddata/unit/test_load_data.py
+++ b/tests/iddata/unit/test_load_data.py
@@ -2,6 +2,8 @@ import datetime
 
 import numpy as np
 import pytest
+
+from iddata.ancillary.population import _load_hsa_populations
 from iddata.loader import DiseaseDataLoader
 from iddata.sources.flusurvnet import FluSurvNetDataSource
 from iddata.sources.ilinet import ILINetDataSource
@@ -129,3 +131,29 @@ def test_load_data_nssp_kwargs(drop_pandemic, as_of, season_expected, wk_end_dat
         assert wk_end_date_actual == wk_end_date_expected
     else:
         assert wk_end_date_actual >= wk_end_date_expected
+
+
+def test_hsa_populations():
+    hsa = _load_hsa_populations()
+
+    assert set(hsa.columns) == {"location", "season", "pop", "agg_level"}
+    assert hsa["pop"].isna().sum() == 0
+    assert (hsa["agg_level"] == "hsa").all()
+
+    # Season format should be "YYYY/YY", not "YYYY.0/..." (float artifact)
+    assert hsa["season"].str.match(r"^\d{4}/\d{2}$").all()
+
+    # All previously-broken HSAs should have real population for a stable season
+    season = hsa[hsa["season"] == "2023/24"]
+    for hsa_id in ["4", "20", "85", "121",   # Connecticut HSAs (2010-2019 Census fallback)
+                   "996", "997"]:              # AK/HI whole-state HSAs (state-total fallback)
+        row = season[season["location"] == hsa_id]
+        assert len(row) == 1, f"HSA {hsa_id} missing from 2023/24"
+        assert row["pop"].iloc[0] > 0, f"HSA {hsa_id} has zero/negative population"
+
+    # Plausibility checks on AK and HI state totals
+    assert season[season["location"] == "996"]["pop"].iloc[0] > 700_000    # Alaska ~730k
+    assert season[season["location"] == "997"]["pop"].iloc[0] > 1_400_000  # Hawaii ~1.4M
+
+    # No (location, season) duplicates — HSA IDs like "20" must not collide with state FIPS "20"
+    assert not hsa[["location", "season"]].duplicated().any()

--- a/tests/iddata/unit/test_sources.py
+++ b/tests/iddata/unit/test_sources.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pandas as pd
 import pytest
+
 from iddata.enums import Disease, SourceType
 from iddata.loader import DiseaseDataLoader
 from iddata.sources.flusurvnet import FluSurvNetDataSource
@@ -143,7 +144,7 @@ class TestDiseaseDataLoaderMerge:
         assert df["pop"].notna().all()
 
 
-    def test_load_nulls_pop_for_hsa(self):
+    def test_load_passes_pop_for_hsa_when_ancillary_has_it(self):
         rows = self._make_source_df("nhsn")
         rows.loc[0, "agg_level"] = "hsa"
         src = MagicMock()
@@ -161,8 +162,8 @@ class TestDiseaseDataLoaderMerge:
         df = loader.load(sources=[src], as_of=datetime.date(2024, 1, 6), ancillary=[anc])
 
         hsa_rows = df[df["agg_level"] == "hsa"]
-        assert hsa_rows["pop"].isna().all()
-        assert hsa_rows["log_pop"].isna().all()
+        assert hsa_rows["pop"].notna().all()
+        assert hsa_rows["log_pop"].notna().all()
 
 
     def test_warns_when_nhsn_hhs_and_drop_pandemic_false(self):

--- a/uv.lock
+++ b/uv.lock
@@ -820,6 +820,7 @@ dependencies = [
     { name = "s3fs", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "s3fs", version = "2026.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "toml" },
+    { name = "xlrd" },
 ]
 
 [package.optional-dependencies]
@@ -854,6 +855,7 @@ requires-dist = [
     { name = "s3fs" },
     { name = "toml" },
     { name = "types-toml", marker = "extra == 'dev'" },
+    { name = "xlrd" },
 ]
 
 [package.metadata.requires-dev]
@@ -2464,6 +2466,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/79/ceea6f7a912220c5fb59154a65ea9e535fdf8d25042671e3cd5352156e20/wrapt-2.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:2de9e20769fe9c1f6dcdc893c6a89287c5ccf8537c90b5de78aed8017697aad5", size = 80418 },
     { url = "https://files.pythonhosted.org/packages/a3/a6/d7835803916569bc05871f3e3fbb42b26f81df3c696d3a6ccddaa194b3c0/wrapt-2.2.1-cp39-cp39-win_arm64.whl", hash = "sha256:585916e210db57b23543342c2f298e42331b617fd0c934caf5c64df44de8640e", size = 79177 },
     { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000 },
+]
+
+[[package]]
+name = "xlrd"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/5a/377161c2d3538d1990d7af382c79f3b2372e880b65de21b01b1a2b78691e/xlrd-2.0.2.tar.gz", hash = "sha256:08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9", size = 100167 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/62/c8d562e7766786ba6587d09c5a8ba9f718ed3fa8af7f4553e8f91c36f302/xlrd-2.0.2-py2.py3-none-any.whl", hash = "sha256:ea762c3d29f4cca48d82df517b6d89fbce4db3107f9d78713e48cd321d5c9aa9", size = 96555 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #41.

The NSSP source returns data at the HSA (Health Service Area) level, using NCI-modified HSA IDs as location codes. Previously `PopulationData` only covered US national, state, and HHS region populations, so `loader.py` nulled out `pop`/`log_pop` for all HSA rows after the ancillary join. This PR adds real HSA-level population so NSSP HSA-level incidence gets accurate denominators. This has important downstream effects in `idmodels` for the GBQR model, which uses population as a feature to potentially split on (but only does the splitting based on state-level NSSP locations and applies that uniformly to the HSA-level ones.)

HSA populations aren't published directly by any agency, so they're derived by aggregating county-level Census data using the [NCI SEER county-to-HSA crosswalk](https://seer.cancer.gov/seerstat/variables/countyattribs/Health.Service.Areas.xls) (~3,200 counties → 952 NCI-modified HSAs), combined with Census county population estimates (2020-2024 and 2010-2019 files).

A few data-quality issues in the source data required special handling:
- **Connecticut (HSAs 4, 20, 85, 121):** CT abolished its 8 counties in 2022 in favor of 9 planning regions, so the 2020-2024 Census file uses new FIPS codes that don't match the crosswalk's old county codes. Fixed by using the 2010-2019 Census file for CT counties only, forward-filled to cover 2020+ seasons.
- **Alaska (HSA 996) and Hawaii (HSA 997):** these "entire state" HSAs are mapped only to placeholder FIPS codes in the crosswalk that don't exist in Census data. Fixed by aggregating real AK/HI county rows directly from the Census file.
- **Stale FIPS codes in AK HSAs 817-820:** `02270` (Wade Hampton) was renamed `02158` (Kusilvak) in 2015, and `02261` (Valdez-Cordova) was split into `02063` (Chugach) + `02066` (Copper River) in 2019. Remapped before joining with Census data.
- **Location code collisions (45 HSAs):** HSA IDs are plain integer strings (e.g. `"20"`) while state FIPS codes are zero-padded (e.g. `"20"` for Kansas), so every state FIPS in 10-56 collides with an HSA ID of the same value. Added an `agg_level` column (`"state"`/`"national"`/`"hhs region"`/`"hsa"`) to all population data and extended the loader join to include it, preventing a many-to-many join that duplicated rows.

Also fixed the CI lint check along the way: `requirements/requirements-dev.txt` and `requirements/requirements.txt` had drifted out of sync with `pyproject.toml` (missing the new `xlrd` dep, and pinning a stale `ruff==0.4.3` that enforces different import-sort formatting than the current version), which caused the first push here to fail `ruff check .` in CI.

## Changes

| File | Change |
|---|---|
| `src/iddata/ancillary/population.py` | Add `_load_county_pop_long()` and `_load_hsa_populations()` (with CT/AK/HI/stale-FIPS handling); add `agg_level` column to `_load_us_census()`; `PopulationData.load()` now concatenates HSA rows |
| `src/iddata/loader.py` | Remove workaround that nulled HSA pop; extend join key to include `agg_level` when present |
| `src/iddata/sources/flusurvnet.py` | Narrow `_load_us_census()` slice used for burden adjustment to avoid column collision with `agg_level` |
| `pyproject.toml` / `uv.lock` | Add `xlrd` dependency (needed to parse the `.xls` crosswalk) |
| `requirements/requirements*.txt` | Regenerate to pick up `xlrd` and bump `ruff` (fixes CI lint mismatch) |
| `tests/` | Add `test_hsa_populations` integration test; update mock test that previously asserted HSA pop was always NaN |

## Test plan
- [x] `ruff check .` passes (verified against both the local dev environment and the exact `requirements/requirements-dev.txt` CI installs from)
- [x] Full test suite passes (`uv run python -m pytest tests/`), including the new `test_hsa_populations` integration test against live Census/SEER data

🤖 Generated with [Claude Code](https://claude.com/claude-code)